### PR TITLE
Convert to Jekyll website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+title: Code + DevOps
+author: Ken Brittain

--- a/_layouts/code.html
+++ b/_layouts/code.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+    <link href="{{ site.url }}/style.css" rel="stylesheet">
+    <title>{{ page.title }}</title>
+    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css">
+</head>
+<body class="hack container">
+
+<h1>{{ page.title }}</h1>
+<p>{{ page.date | date_to_string }}</p>
+
+{{ content }}
+
+<a href="{{ site.url }}/index.html">&lt; back</a>
+<p></p>
+
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/components/prism-core.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
+
+</body>
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+    <link href="{{ site.url }}/style.css" rel="stylesheet">
+    <title>{{ site.title }}</title>
+    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
+</head>
+<body class="hack container">
+
+{{ content }}
+
+</body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+    <link href="{{ site.url }}/style.css" rel="stylesheet">
+    <title>{{ page.title }}</title>
+    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
+</head>
+<body class="hack container">
+
+<h1>{{ page.title }}</h1>
+<p>{{ page.date | date_to_string }}</p>
+
+{{ content }}
+
+<a href="{{ site.url }}/index.html">&lt; back</a>
+<p></p>
+
+</body>
+</html>

--- a/_posts/2021-09-12-zero-based-blog.html
+++ b/_posts/2021-09-12-zero-based-blog.html
@@ -1,0 +1,7 @@
+---
+permalink: /posts/0-zero-based-blog.html
+title: Zero Based Blog
+layout: post
+---
+
+<p>Seriously, what did you think this post would be?</p>

--- a/_posts/2021-09-14-keep-it-simple-stupid.html
+++ b/_posts/2021-09-14-keep-it-simple-stupid.html
@@ -1,15 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>Keep it Simple Stupid</title>
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>Keep it Simple Stupid</h1>
-<p>9/14/2021 (edited: 9/22/2021)</p>
+---
+permalink: /posts/1-keep-it-simple-stupid.html
+title: Keep it Simple Stupid
+layout: post
+---
 
 <p>
     There are companies being funded that solely provide blogging tools for 
@@ -73,8 +66,3 @@
   mobile nicely.
 </p>
 
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-</body>
-</html>

--- a/_posts/2021-09-22-new-keyword-interview-question.html
+++ b/_posts/2021-09-22-new-keyword-interview-question.html
@@ -1,17 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>New Keyword Interview Question</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css">
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>New Keyword Interview Question</h1>
-<p>9/22/2021</p>
-
+---
+permalink: /posts/2-new-keyword-interview-question.html
+layout: code
+title: New Keyword Interview Question
+---
 <p>
   Part of the duties of a senior team member is to interview
   candidates for open positions. This task comes up for various
@@ -167,11 +158,3 @@
   the <code>new</code> modified.
 </p>
 
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/components/prism-core.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
-
-</body>
-</html>

--- a/_posts/2021-09-28-github-pages-hidden-files.html
+++ b/_posts/2021-09-28-github-pages-hidden-files.html
@@ -1,15 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>GitHub Pages Hidden Files</title>
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>GitHub Pages Hidden Files</h1>
-<p>9/28/2021</p>
+---
+permalink: /posts/3-github-pages-hidden-files.html
+layout: post
+title: GitHub Pages Hidden Files
+---
 
 <p>
     This blog is a static HTML website. That means the files contained within it are
@@ -50,9 +43,3 @@
     <li><a href="https://stackoverflow.com/questions/58699725/how-can-one-get-github-pages-to-serve-dot-files-like-rfc5785s-well-known">How can one get github pages to serve dot files like RFC5785's /.well-known/?</a></li>
     <li><a href="https://stackoverflow.com/questions/20893913/does-pages-github-com-support-directory-names-with-a-preceeding-dot/20910276">Does pages.github.com support directory names with a preceeding . (dot)?</a></li>
 </ul>
-
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-</body>
-</html>

--- a/_posts/2021-10-06-phases-of-devops-adoption.html
+++ b/_posts/2021-10-06-phases-of-devops-adoption.html
@@ -1,15 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>Phases of DevOps Adoption</title>
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>Phases of DevOps Adoption</h1>
-<p>10/6/2021</p>
+---
+permalink: /posts/4-phases-of-devops-adoption.html
+layout: post
+title: Phases of DevOps Adoption
+---
 
 <p>
     In my tenure supporting software teams and implementing DevOps, I have come to

--- a/_posts/2021-10-19-two-favorite-csharp-10-features.html
+++ b/_posts/2021-10-19-two-favorite-csharp-10-features.html
@@ -1,15 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>Two Favorite C# 10 Features</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css">
-</head>
-<body class="hack container">
-
-<h1>Two Favorite C# 10 Features</h1>
-<p>10/19/2021 (Updated 11/2/2021)</p>
+---
+permalink: /posts/5-two-favorite-csharp-10-features.html
+title: Two Favorite C# 10 Features
+layout: code
+---
 
 <p>
     C# 10 is being released in November 2021 along with .NET 6. There are several
@@ -134,11 +127,3 @@
     <em>Updated: edited using block code to include <code>global</code> to be more clear.</em>
 </p>
 
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/components/prism-core.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
-
-</body>
-</html>

--- a/_posts/2021-10-30-yaml-runbooks.html
+++ b/_posts/2021-10-30-yaml-runbooks.html
@@ -1,16 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>YAML Runbooks</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css">
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>YAML Runbooks</h1>
-<p>10/30/2021</p>
+---
+permalink: /posts/6-yaml-runbooks.html
+title: YAML Runbooks
+layout: code
+---
 
 <p>
     If you have worked in IT for  any length of time you have heard that you need
@@ -94,11 +86,3 @@
     viewing.
 </p>
 
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/components/prism-core.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
-
-</body>
-</html>

--- a/_posts/2021-11-09-runbook-compiler.html
+++ b/_posts/2021-11-09-runbook-compiler.html
@@ -1,19 +1,11 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>Runbook Compiler</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css">
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>Runbook Compiler</h1>
-<p>10/9/2021</p>
+---
+permalink: /posts/7-runbook-compiler.html
+title: Runbook Compiler
+layout: code
+---
 
 <p>
-    In this <a href="6-yaml-runbooks.html">post</a> I recommended storing your
+    In this <a href="2021-10-30-yaml-runbooks.html">post</a> I recommended storing your
     runbooks in the YAML format. The idea was to keep the system documentation,
     and runbooks are a form of system documentation, in a developer friendly
     format. This simple step would enable document changes to be committed along
@@ -102,11 +94,3 @@ will include any file in the runbooks source directory matching the wildcard
     </tr>
 </table>
 
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/components/prism-core.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
-
-</body>
-</html>

--- a/_posts/2021-11-17-csharp-project-layout.html
+++ b/_posts/2021-11-17-csharp-project-layout.html
@@ -1,15 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>Runbook Compiler</title>
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>Runbook Compiler</h1>
-<p>10/17/2021</p>
+---
+permalink: /posts/8-csharp-project-layout.html
+title: C# Project Layout
+layout: code
+---
 
 <p>
     If you have developed any software in Java the chances are that you have
@@ -102,9 +95,3 @@
     <em>If you are working on a Microsoft project then the du jure standard
         appears to be something entirely different. Then I wish you Godspeed.</em>
 </p>
-
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-</body>
-</html>

--- a/_posts/2021-11-24-using-spectre-console-for-cli.html
+++ b/_posts/2021-11-24-using-spectre-console-for-cli.html
@@ -1,16 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>Using Spectre.Console for CLI</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css">
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>Using Spectre.Console for CLI</h1>
-<p>19/24/2021</p>
+---
+permalink: /posts/9-using-spectre-console-for-cli.html
+title: Using Spectre.Console for CLI
+layout: code
+---
 
 <p>
     I have used the <a href="https://github.com/fschwiet/ManyConsole/">ManyConsole</a>
@@ -180,9 +172,3 @@
 
 <a href="../index.html">&lt; back</a>
 <p></p>
-
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/components/prism-core.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
-
-</body>
-</html>

--- a/_posts/2021-11-27-unit-testing-system-io.html
+++ b/_posts/2021-11-27-unit-testing-system-io.html
@@ -1,16 +1,8 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="../style.css" rel="stylesheet">
-    <title>Unit Testing System.IO</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism.css">
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body class="hack container">
-
-<h1>Unit Testing System.IO</h1>
-<p>11/27/2021</p>
+---
+permalink: /posts/10-unit-testing-system-io.html
+title: Unit Testing System.IO
+layout: code
+---
 
 <p>
     My advice is simple: use the <a href="https://github.com/TestableIO/System.IO.Abstractions">System.IO.Abstractions</a>
@@ -193,12 +185,3 @@
     Using this library for greenfield development is a no-brainer. Existing code
     will be modified to utilize this library as changes are required.
 </p>
-
-<a href="../index.html">&lt; back</a>
-<p></p>
-
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/components/prism-core.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/plugins/autoloader/prism-autoloader.min.js"></script>
-
-</body>
-</html>

--- a/index.html
+++ b/index.html
@@ -1,35 +1,17 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <link href="./style.css" rel="stylesheet">
-    <title>Code + DevOps</title>
-    <script defer data-domain="kenbrittain.com" src="https://plausible.io/js/plausible.js"></script>
-  </head>
-<body class="hack container">
-
+---
+layout: default
+---
 <h1>Code + DevOps</h1>
 <p>
     <a href="./projects.html">Projects</a> <a href="./about.html">About</a>
 </p>
 
 <ul>
-    <li>[10] <a href="posts/10-unit-testing-system-io.html">Unit Testing System.IO</a></li>
-    <li>[9] <a href="posts/9-using-spectre-console-for-cli.html">Using Spectre.Console for CLI</a></li>
-    <li>[8] <a href="posts/8-csharp-project-layout.html">C# Project Layout</a></li>
-    <li>[7] <a href="posts/7-runbook-compiler.html">Runbook Compiler</a></li>
-    <li>[6] <a href="posts/6-yaml-runbooks.html">YAML Runbooks</a></li>
-    <li>[5] <a href="posts/5-two-favorite-csharp-10-features.html">Two Favorite C# 10 Features</a></li>
-    <li>[4] <a href="posts/4-phases-of-devops-adoption.html">Phases of DevOps Adoption</a></li>
-    <li>[3] <a href="posts/3-github-pages-hidden-files.html">GitHub Pages Hidden Files</a></li>
-    <li>[2] <a href="posts/2-new-keyword-interview-question.html">New Keyword Interview Question</a></li>
-    <li>[1] <a href="posts/1-keep-it-simple-stupid.html">Keep it Simple Stupid</a></li>
-    <li>[0] <a href="posts/0-zero-based-blog.html">Zero Based Blog</a></li>
+    {% for post in site.posts %}
+    <li>[{{ forloop.rindex0 }}] <a href="{{ post.url }}">{{ post.title }}</a></li>
+    {% endfor %}
 </ul>
 
 <p>
     <em>All opinions expressed are my own and not that of my employer.</em>
 </p>
-
-</body>
-</html>


### PR DESCRIPTION
The goal of the static website was to get it up and running. Jekyll was
not used because there were too many choices in templates, etc. Now
that posts are coming, the static web is manual, and producing too many
errors (dates, titles, etc.) because of the copying.

The goal now is to get a sitemap and rss feed generated so the blog can
be submitted to the search engines. After finding a half dozen typos in
content (not related to the text) I figured now was the time to switch.

The same post index method is used (via permalinks) because I really
like it. Also, the work is similar because in the static website this
was done for all href in the anchors tags.