### PR TITLE
Add RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,30 @@
+---
+layout:
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ site.title | xml_escape }}</title>
+        <description>{{ site.description | xml_escape }}</description>
+        <link>{{ site.url }}{{ site.baseurl }}/</link>
+        <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+        <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+        <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+        <generator>Jekyll v{{ jekyll.version }}</generator>
+        {% for post in site.posts limit:10 %}
+        <item>
+            <title>{{ post.title | xml_escape }}</title>
+            <description>{{ post.content | xml_escape }}</description>
+            <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+            <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+            <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+            {% for tag in post.tags %}
+            <category>{{ tag | xml_escape }}</category>
+            {% endfor %}
+            {% for cat in post.categories %}
+            <category>{{ cat | xml_escape }}</category>
+            {% endfor %}
+        </item>
+        {% endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
Part of the reasoning for migrating to Jekyll was to get the RSS feed
active without having to manually create it. The attempts at that were
filled with errors (and I discovered more errors inside the website as
well). Manual got it started but was never a good idea (or long term).